### PR TITLE
fixed flake.nix 

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -19,22 +19,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -71,63 +55,6 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
-      "inputs": {
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_4": {
-      "inputs": {
-        "systems": "systems_4"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "zls-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1753749649,
@@ -160,28 +87,11 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1734991663,
-        "narHash": "sha256-8T660guvdaOD+2/Cj970bWlQwAyZLKrrbkhYOFcY1YE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "6c90912761c43e22b6fb000025ab96dd31c971ff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "esp-idf": "esp-idf",
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2",
-        "zls-overlay": "zls-overlay"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {
@@ -211,81 +121,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "zig-overlay": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_4",
-        "nixpkgs": [
-          "zls-overlay",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1735086567,
-        "narHash": "sha256-I+ORk8or5eEBdK/2VEL2jDqBmV/sWaRsHTqr+DrEvdI=",
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "rev": "bc4fd6e14e166769839bc0085803b8c21771750d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mitchellh",
-        "repo": "zig-overlay",
-        "type": "github"
-      }
-    },
-    "zls-overlay": {
-      "inputs": {
-        "flake-utils": "flake-utils_3",
-        "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_3",
-        "zig-overlay": "zig-overlay"
-      },
-      "locked": {
-        "lastModified": 1736625676,
-        "narHash": "sha256-QPrheX5S8l4ygyJe4zM+IsRwgqt25KQNqHlQpGQKrIk=",
-        "owner": "zigtools",
-        "repo": "zls",
-        "rev": "edd8f2264ea45f7370bac4aba809bc179d96627e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "zigtools",
-        "repo": "zls",
-        "rev": "edd8f2264ea45f7370bac4aba809bc179d96627e",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,12 @@
         platformSrc = if system == "x86_64-linux" then
           {
             url = "https://github.com/kassane/zig-espressif-bootstrap/releases/download/0.14.0-xtensa/zig-relsafe-x86_64-linux-musl-baseline.tar.xz";
-            sha256 = "sha256-KAFGYgUP1poW79QrLwq7JI07VyZayWbBDqcGT6NQbug=";
+            sha256 = "sha256-czEQX03pDNzoh9SGhWfs5miU7vK1md7sYCd3lHSLLCA=";
           }
         else if system == "aarch64-linux" then
           {
             url = "https://github.com/kassane/zig-espressif-bootstrap/releases/download/0.14.0-xtensa/zig-relsafe-aarch64-linux-musl-baseline.tar.xz";
-            sha256 = "sha256-1bnaav5a8gp108izghlcpdnl1y0rl5jzzmzx47q234k3h5m42jb2";
+            sha256 = "sha256-MUrTa7hI1Gx4vCM+0Tnu5D7agoUWzPb11pufIBptFCQ=";
           }
         else
           throw "Unsupported platform: ${system}";

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,16 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    zls-overlay.url = "github:zigtools/zls/edd8f2264ea45f7370bac4aba809bc179d96627e";
     esp-idf.url = "github:mirrexagon/nixpkgs-esp-dev";
   };
 
-  outputs = { self, nixpkgs, flake-utils, zls-overlay, esp-idf, ... }:
+  outputs = { self, nixpkgs, flake-utils, esp-idf, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
             esp-idf.overlays.default
-            (final: prev: {
-              zls = zls-overlay.packages.${system}.default;
-            })
           ];
         };
 
@@ -56,7 +52,7 @@
               '';
             })
 
-            zls
+            pkgs.zls
 
             esp-idf-full
           ];


### PR DESCRIPTION
## Changes
- Removed the zls-overlay input and overlay.
- Switched to using pkgs.zls from nixpkgs.
- Updated sha256 values for the Zig Espressif bootstrap tarballs:
    - x86_64-linux: sha256-czEQX03pDNzoh9SGhWfs5miU7vK1md7sYCd3lHSLLCA=
    - aarch64-linux: sha256-MUrTa7hI1Gx4vCM+0Tnu5D7agoUWzPb11pufIBptFCQ=

## Why
I swapped to `pkgs.zls` because `zls-overlay` was failing to get the overlay due to `https://ziglang.org/builds/zig-linux-x86_64-0.14.0-dev.2563+af5e73172.tar.xz` returning a 404. 
I am not really sure if this will break anything long term, but on my end `zls` only works with the `esp_idf` module if I remove it from the build script and make it all relative. I worked on this for about 9 hours but I could not find a work around.

I also updated the hashes because  kassane/zig-esp-idf-sample@f59113138ef141a3e6e60fd876994237f9b2ffb2 updated the links without updating the `sha256` values.