### PR TITLE
Update DOCKER_TAG to release-v6.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			"DOCKER_TAG": "v6.0"
+			"DOCKER_TAG": "release-v6.0"
 		}
 	},
 	"mounts": [


### PR DESCRIPTION
v6.0 is not a valid tag. See: https://hub.docker.com/r/espressif/idf/tags?name=v6.0

Resolves:
https://github.com/kassane/zig-esp-idf-sample/issues/38