### PR TITLE
Add Kconfig menu for building examples and fix http-server example

### DIFF
--- a/include/stubs.h
+++ b/include/stubs.h
@@ -165,4 +165,11 @@ typedef unsigned int mode_t;
 #include "matter_stubs.h"
 #endif
 
+#ifdef ESP_IDF_COMP_ESP_HTTP_SERVER_ENABLED
+static inline httpd_config_t zig_httpd_default_config(void) {
+    httpd_config_t config = HTTPD_DEFAULT_CONFIG();
+    return config;
+}
+#endif
+
 #endif // STUBS_H

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -64,4 +64,29 @@ menu "Example Configuration"
             bool "WAPI PSK"
     endchoice
 
+    choice ZIG_EXAMPLE_SELECTION
+        prompt "Select Zig Example to build"
+        default ZIG_EXAMPLE_DEFAULT
+        config ZIG_EXAMPLE_DEFAULT
+            bool "Default (main/app.zig)"
+        config ZIG_EXAMPLE_SMARTLED_RGB
+            bool "SmartLED RGB"
+        config ZIG_EXAMPLE_WIFI_STATION
+            bool "WiFi Station"
+        config ZIG_EXAMPLE_DSP_MATH
+            bool "DSP Math"
+        config ZIG_EXAMPLE_GPIO_BLINK
+            bool "GPIO Blink"
+        config ZIG_EXAMPLE_HTTP_SERVER
+            bool "HTTP Server"
+        config ZIG_EXAMPLE_BLE_GATT_SERVER
+            bool "BLE GATT Server"
+        config ZIG_EXAMPLE_I2C_SCAN
+            bool "I2C Scan"
+        config ZIG_EXAMPLE_UART_ECHO
+            bool "UART Echo"
+        config ZIG_EXAMPLE_MATTER_LIGHT
+            bool "Matter Light"
+    endchoice
+
 endmenu

--- a/main/examples/http-server.zig
+++ b/main/examples/http-server.zig
@@ -101,7 +101,7 @@ export fn app_main() callconv(.c) void {
         .sta = .{
             .ssid = std.mem.zeroes([32]u8),
             .password = std.mem.zeroes([64]u8),
-            .threshold = .{ .authmode = sys.WIFI_AUTH_WPA2_PSK },
+            .threshold = .{ .rssi = 0, .rssi_5g_adjustment = 0, .authmode = sys.WIFI_AUTH_WPA2_PSK },
             .sae_pwe_h2e = sys.WPA3_SAE_PWE_BOTH,
             .sae_h2e_identifier = std.mem.zeroes([32]u8),
         },
@@ -123,15 +123,7 @@ export fn app_main() callconv(.c) void {
 }
 
 fn startHttpServer() !void {
-    var config = std.mem.zeroes(sys.httpd_config_t);
-    config.server_port = 80;
-    config.stack_size = 4096;
-    config.task_priority = 5;
-    config.max_uri_handlers = 8;
-    config.max_resp_headers = 8;
-    config.recv_wait_timeout = 5;
-    config.send_wait_timeout = 5;
-    config.lru_purge_enable = false;
+    var config = sys.zig_httpd_default_config();
 
     const server = try idf.http.Server.start(&config);
 


### PR DESCRIPTION
Thank you for creating and maintaining this project! I ran into some issues trying to get the http-server example working and these were the changes I made to resolve my issues.

### Changes
- Add Kconfig option to toggle and build the examples provided.
- Add `zig_httpd_default_config` into `include/stubs.h` as workaround to be able to use `HTTPD_DEFAULT_CONFIG`
- Update http-server example to use the recently made wifiConfig fix

P.S. in `idf.py menuconfig` I had to update `ESP_MAIN_TASK_STACK_SIZE` and `ESP_SYSTEM_EVENT_TASK_STACK_SIZE` to `8192` from the default values used. Not sure if you can set new defaults or maybe just add a note in the getting-started.md documentation