### PR TITLE
fix smartled-rgb.zig example on Zig 0.16.0 and IDF v6.0.1

### DIFF
--- a/cmake/patch.cmake
+++ b/cmake/patch.cmake
@@ -114,6 +114,7 @@ if(HAS_LED_STRIP EQUAL 1)
     string(REGEX REPLACE "pub const led_strip_rmt_config_t[^;]*;" "" FILE_CONTENT "${FILE_CONTENT}")
     string(REGEX REPLACE "pub const led_color_component_format_t[^;]*;" "" FILE_CONTENT "${FILE_CONTENT}")
     string(REGEX REPLACE "pub const led_strip_config_t = extern struct \\{[^}]*\\};" "" FILE_CONTENT "${FILE_CONTENT}")
+    string(REGEX REPLACE "pub const led_strip_config_t = opaque \\{[^}]*\\};" "" FILE_CONTENT "${FILE_CONTENT}")
 endif()
 
 # ============================================================================

--- a/imports/led-strip.zig
+++ b/imports/led-strip.zig
@@ -12,7 +12,7 @@ pub const LedModel = enum(sys.led_model_t) {
 pub const LedStripHandle = sys.led_strip_handle_t;
 
 pub const ColorComponentFormat = extern union {
-    format: packed struct {
+    format: packed struct(u32) {
         r_pos: u2, // Position of the red channel in the color order: 0~3
         g_pos: u2, // Position of the green channel in the color order: 0~3
         b_pos: u2, // Position of the blue channel in the color order: 0~3


### PR DESCRIPTION
On Zig 0.16.0 and IDF v6.0.1 led_strip_config_t is translated in idf_sys.zig as:

```Zig
pub const led_strip_config_t = opaque {
    pub const led_strip_new_rmt_device = __root.led_strip_new_rmt_device;
    pub const led_strip_new_spi_device = __root.led_strip_new_spi_device;
    pub const device = __root.led_strip_new_rmt_device;
};
```

Current regexp expects `extern struct` instead of `opaque` and it fails
to remove generated declaration so we get duplicate after applying
patch.

```sh
/home/ianic/Code/esp32/zig-esp-idf-sample/imports/idf-sys.zig:12439:11: error: duplicate struct member name 'led_strip_config_t'
pub const led_strip_config_t = opaque {
          ^~~~~~~~~~~~~~~~~~
/home/ianic/Code/esp32/zig-esp-idf-sample/imports/idf-sys.zig:29393:11: note: duplicate name here
pub const led_strip_config_t = extern struct {
          ^~~~~~~~~~~~~~~~~~
```


Fixing build error in imports/led-strip.zig
```sh
imports/led-strip.zig:15:20: error: extern unions cannot contain fields of type 'led-strip.ColorComponentFormat__struct_1011'    format: packed struct {
            ~~~~~~~^~~~~~
imports/led-strip.zig:15:20: note: inferred backing integer of packed
struct has unspecified signedness