### PR TITLE
fix(#71): add uart patches for zig translate c to replace opaque uart…

### DIFF
--- a/cmake/patch.cmake
+++ b/cmake/patch.cmake
@@ -53,6 +53,9 @@ endif()
 # Remove portTICK_PERIOD_MS (will be replaced with custom version)
 string(REGEX REPLACE "pub const portTICK_PERIOD_MS[^;]*;" "" FILE_CONTENT "${FILE_CONTENT}")
 
+# Remove uart_config_t (will be replaced with custom version)
+string(REGEX REPLACE "pub const uart_config_t = opaque[^;]*;" "" FILE_CONTENT "${FILE_CONTENT}")
+
 # ============================================================================
 # Handle bitfield-related opaque types and unions
 # ============================================================================
@@ -151,6 +154,11 @@ if(HAS_LED_STRIP EQUAL 1)
         "led_strip/led_strip_config_t.zig"
     )
 endif()
+
+# Add UART patches
+list(APPEND PATCH_FILES
+        "uart/uart_config_t.zig"
+)
 
 # Apply each patch file
 foreach(PATCH_FILE IN LISTS PATCH_FILES)

--- a/imports/uart.zig
+++ b/imports/uart.zig
@@ -135,7 +135,7 @@ pub const PinConfig = struct {
 };
 
 pub fn setPin(port: Port, pins: PinConfig) !void {
-    return errors.espCheckError(sys.uart_set_pin(port, pins.tx, pins.rx, pins.rts, pins.cts));
+    return errors.espCheckError(sys._uart_set_pin4(port, pins.tx, pins.rx, pins.rts, pins.cts));
 }
 
 /// Drive RTS line manually (level: true = high, false = low).

--- a/main/examples/uart-echo.zig
+++ b/main/examples/uart-echo.zig
@@ -29,9 +29,8 @@ export fn app_main() callconv(.c) void {
         .parity = sys.UART_PARITY_DISABLE,
         .stop_bits = sys.UART_STOP_BITS_1,
         .flow_ctrl = sys.UART_HW_FLOWCTRL_DISABLE,
-        .source_clk = sys.UART_SCLK_DEFAULT,
         .rx_flow_ctrl_thresh = 0,
-        .lp_source_clk = 0,
+        .clk_source = .{.source_clk = sys.UART_SCLK_DEFAULT},
         .flags = .{ .backup_before_sleep = 0, .allow_pd = 0 },
     };
 
@@ -65,6 +64,7 @@ export fn app_main() callconv(.c) void {
             log.err("readBytes: {s}", .{@errorName(err)});
             continue;
         };
+
         if (n > 0) {
             _ = idf.uart.writeBytes(UART_PORT, buf[0..n]) catch |err| {
                 log.err("writeBytes: {s}", .{@errorName(err)});

--- a/main/examples/uart-echo.zig
+++ b/main/examples/uart-echo.zig
@@ -30,7 +30,7 @@ export fn app_main() callconv(.c) void {
         .stop_bits = sys.UART_STOP_BITS_1,
         .flow_ctrl = sys.UART_HW_FLOWCTRL_DISABLE,
         .rx_flow_ctrl_thresh = 0,
-        .clk_source = .{.source_clk = sys.UART_SCLK_DEFAULT},
+        .clk_source = .{ .source_clk = sys.UART_SCLK_DEFAULT },
         .flags = .{ .backup_before_sleep = 0, .allow_pd = 0 },
     };
 

--- a/patches/uart/uart_config_t.zig
+++ b/patches/uart/uart_config_t.zig
@@ -1,0 +1,27 @@
+const has_lp_uart = if (@hasDecl(@This(), "SOC_UART_LP_NUM"))
+    @field(@This(), "SOC_UART_LP_NUM") >= 1
+else false;
+
+const lp_source_clk_type = if (has_lp_uart) @field(@This(), "lp_uart_sclk_t") else void;
+
+pub const uart_source_clk = extern union {
+    source_clk: uart_sclk_t,
+    lp_source_clk: lp_source_clk_type,
+};
+
+pub const uart_config_flags = packed struct(u32) {
+    allow_pd: u1 = 0,
+    backup_before_sleep: u1 = 0,
+    _padding: u30 = 0,
+};
+
+pub const uart_config_t = extern struct {
+    baud_rate: c_int = 115200,
+    data_bits: uart_word_length_t = UART_DATA_8_BITS,
+    parity: uart_parity_t = UART_PARITY_DISABLE,
+    stop_bits: uart_stop_bits_t = UART_STOP_BITS_1,
+    flow_ctrl: uart_hw_flowcontrol_t = UART_HW_FLOWCTRL_DISABLE,
+    rx_flow_ctrl_thresh: u8 = 122,
+    clk_source: uart_source_clk = undefined,
+    flags: uart_config_flags = undefined,
+};


### PR DESCRIPTION
This pull request fixes a zig translate c issue where `uart_config_t` was translated as an opaque type.

This provides a replacement for `uart_config_t` through the patch mechanism as well as a small fix for the sample uart app due to the use of a variadic function.

I have tested this on my ESP32 device. However, I do not have an ESP32 C6 to test the low-power uart functionality properly. The code compiles properly when I `idf set-target esp32c6`.

closes #71 